### PR TITLE
Feature/edit post

### DIFF
--- a/app/api/blogs/post/edit/route.ts
+++ b/app/api/blogs/post/edit/route.ts
@@ -2,79 +2,93 @@ import { findTags } from "@libs/server/findTags";
 import prismaclient from "@libs/server/prismaClient";
 
 import {NextResponse} from 'next/server'
-import {EditPost} from '@types'
+import {PostPostJson} from '@types'
+import {findCategory} from '@libs/server/findCategoryId'
 
-export  async function POST(req: Request) {
 
-    const { id, title, markdown, tags, description }: EditPost = await req.json();
+export async function POST(req: Request) {
+
+    const {searchParams} = new URL(req.url)
+    const id = searchParams.get('id') ? parseInt(searchParams.get('id')+"") : 1;
+
+
+    const {  title, markdown, tags, description, category }: PostPostJson = await req.json();
+
 
     try {
+        const tagsArray = tags?.map(item=>item);
       // 같은 tag가 존재한다면 해당 tag id 반환
-      const [tagsTag, tagsId] = await findTags(tags);
+      const [tagsTag, tagsId] = await findTags(tagsArray);
+        const CategoryId = await findCategory(category ?? "");
 
       if (tagsTag?.length === 0 || (tags && tags.length > [tagsTag].length)) {
-        let filterTags = tags?.filter((tag) => !tagsTag?.includes(tag));
+        let filterTags = tags?.filter((item) => !tagsTag?.includes(item))
 
         filterTags &&
           (await prismaclient.tag.createMany({
-            data: filterTags?.map((tag) => ({ tag })),
+            data: filterTags?.map((tag) => ({ tag})),
             skipDuplicates: true,
           }));
 
-        const combinedTags = [...new Set(tagsTag!.concat(filterTags!))];
+          const combinedTags = [...new Set(tagsTag!.concat(filterTags!))];
 
-        const relatedTags = await prismaclient.tag.findMany({
-          where: {
-            tag: { in: combinedTags },
-          },
-        });
+          const relatedTags = await prismaclient.tag.findMany({
+              where: {
+                  tag: {in: combinedTags},
+              },
+          });
 
-        await prismaclient.post.update({
-          data: {
-            title: title!,
-            content: markdown!,
-            tags: {
-              connect: relatedTags.map((tag) => ({ id: +tag.id })),
-            },
-            description,
-          },
-          where: {
-            id,
-          },
-        });
+
+          await prismaclient.post.update({
+              data: {
+                  title: title!,
+                  content: markdown!,
+                  tags: {
+                      connect: relatedTags.map((tag) => ({id: +tag.id})),
+                  },
+                  description,
+                  category: category ? {connect: {id: CategoryId?.id}} : {},
+              },
+              where: {
+                  id,
+              },
+          });
       } else {
-        await prismaclient.post.update({
-          data: {
-            title: title!,
-            content: markdown!,
-            description,
-            tags: {
-              connect: tagsId!.map((tag) => ({ id: +tag })),
-            },
-          },
-          where: {
-            id,
-          },
-        });
+          await prismaclient.post.update({
+              data: {
+                  title: title!,
+                  content: markdown!,
+                  description,
+                  tags: {
+                      connect: tagsId!.map((tag) => ({id: +tag})),
+                  },
+                  category: category ? {connect: {id: CategoryId?.id}} : {},
+              },
+              where: {
+                  id,
+              },
+          });
       }
 
-      if (tags?.length === 0) {
-        await prismaclient.post.update({
-          data: {
-            title: title!,
-            content: markdown!,
-            description,
-          },
-          where: {
-            id,
-          },
-        });
-      }
+        if (tags?.length === 0) {
+            await prismaclient.post.update({
+                data: {
+                    title: title!,
+                    content: markdown!,
+                    description,
+                    category: category ? {connect: {id: CategoryId?.id}} : {},
+
+                },
+                where: {
+                    id,
+                },
+            });
+        }
     } catch (err) {
-      console.log(err);
-      return NextResponse.json({ ok: false, message: `error occurred ${err}` });
+        console.log(err);
+        return NextResponse.json({ok: false, message: `error occurred ${err}`});
     }
 
-    return NextResponse.json({ ok: true });
-  }
+    return NextResponse.json({ok: true});
+}
 

--- a/app/api/blogs/post/route.ts
+++ b/app/api/blogs/post/route.ts
@@ -1,27 +1,17 @@
 import { findCategory } from "@libs/server/findCategoryId";
 import { findTags } from "@libs/server/findTags";
 import prismaclient from "@libs/server/prismaClient";
-import {IPostJson} from '../../../blogs/post/page'
 import {NextResponse} from 'next/server'
+import {PostPostJson} from '@types'
 
 export  async function POST(req: Request) {
-  const { title, markdown, tags, description, category }: IPostJson = await req.json();
+  const { title, markdown, tags, description, category }: PostPostJson = await req.json();
 
   try {
     // 같은 tag가 존재한다면 해당 tag id 반환
     const [tagsTag, tagsId] = await findTags(tags);
     const CategoryId = await findCategory(category ? category : "");
-    const confirmCategoryId =
-        CategoryId === null && category !== ""
-            ? await prismaclient.category.create({
-              data: {
-                category: category!,
-              },
-              select: {
-                id: true,
-              },
-            })
-            : CategoryId;
+
 
     // 만약 해당하는 tag id가 없거나 tags, tagsTag 길이다 다르다면 추가한다.
     if (tagsTag?.length === 0 || (tags && tags.length > [tagsTag].length)) {
@@ -51,7 +41,7 @@ export  async function POST(req: Request) {
             connect: relatedTags.map((tag) => ({ id: +tag.id })),
           },
           category:
-              category !== "" ? { connect: { id: confirmCategoryId?.id } } : {},
+              category !== "" ? { connect: { id: CategoryId?.id } } : {},
         },
       });
     } else {
@@ -66,7 +56,7 @@ export  async function POST(req: Request) {
             connect: tagsId?.map((tag) => ({ id: +tag })),
           },
           category:
-              category !== "" ? { connect: { id: confirmCategoryId?.id } } : {},
+              category !== "" ? { connect: { id: CategoryId?.id } } : {},
         },
       });
     }
@@ -80,7 +70,7 @@ export  async function POST(req: Request) {
           views: 0,
           description,
           category:
-              category !== "" ? { connect: { id: confirmCategoryId?.id } } : {},
+              category !== "" ? { connect: { id: CategoryId?.id } } : {},
         },
       });
     }

--- a/app/api/blogs/post/route.ts
+++ b/app/api/blogs/post/route.ts
@@ -8,29 +8,9 @@ export  async function POST(req: Request) {
   const { title, markdown, tags, description, category }: PostPostJson = await req.json();
 
   try {
-    // 같은 tag가 존재한다면 해당 tag id 반환
-    const [tagsTag, tagsId] = await findTags(tags);
+    const tagsId = await findTags(tags!);
     const CategoryId = await findCategory(category ? category : "");
 
-
-    // 만약 해당하는 tag id가 없거나 tags, tagsTag 길이다 다르다면 추가한다.
-    if (tagsTag?.length === 0 || (tags && tags.length > [tagsTag].length)) {
-      let filterTags = tags?.filter((tag) => !tagsTag?.includes(tag));
-
-      filterTags &&
-      (await prismaclient.tag.createMany({
-        data: filterTags?.map((tag) => ({ tag })),
-        skipDuplicates: true,
-      }));
-
-      const combinedTags = [...new Set(tagsTag!.concat(filterTags!))];
-
-      const relatedTags = await prismaclient.tag.findMany({
-        where: {
-          tag: { in: combinedTags },
-        },
-      });
-
       await prismaclient.post.create({
         data: {
           title: title!,
@@ -38,42 +18,15 @@ export  async function POST(req: Request) {
           views: 0,
           description,
           tags: {
-            connect: relatedTags.map((tag) => ({ id: +tag.id })),
+            connect: tagsId?.map((itemId) => ({ id: itemId })),
           },
           category:
               category !== "" ? { connect: { id: CategoryId?.id } } : {},
         },
       });
-    } else {
-      // 전부 있던 태그로 이루어진 post
-      await prismaclient.post.create({
-        data: {
-          title: title!,
-          content: markdown!,
-          views: 0,
-          description,
-          tags: {
-            connect: tagsId?.map((tag) => ({ id: +tag })),
-          },
-          category:
-              category !== "" ? { connect: { id: CategoryId?.id } } : {},
-        },
-      });
-    }
 
-    // 태그가 없는 post
-    if (tags?.length === 0) {
-      await prismaclient.post.create({
-        data: {
-          title: title!,
-          content: markdown!,
-          views: 0,
-          description,
-          category:
-              category !== "" ? { connect: { id: CategoryId?.id } } : {},
-        },
-      });
-    }
+
+
   } catch (err) {
     console.log(err);
 

--- a/app/blogs/post/edit/page.tsx
+++ b/app/blogs/post/edit/page.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+
+import dynamic from 'next/dynamic'
+import {useRouter} from 'next/navigation'
+import React, {useRef, useState} from 'react'
+import {useMutation} from '@libs/client/useMutation'
+import {useSession} from 'next-auth/react'
+import {MutationResult, PostPostJson} from '@types'
+import {useSelector} from 'react-redux'
+import {ReduxSliceState} from '../../../../store/modules'
+import "@uiw/react-md-editor/markdown-editor.css";
+import "@uiw/react-markdown-preview/markdown.css";
+
+const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+
+export default function Page() {
+    const router = useRouter();
+
+    const editPostData = useSelector( (state:ReduxSliceState) => state.editPostReducer);
+
+    const editPostDataTags = editPostData.tags.join("")
+
+    const tagsRef = useRef<HTMLInputElement>(null);
+    const titleRef = useRef<HTMLInputElement>(null);
+    const descriptionRef = useRef<HTMLInputElement>(null);
+    const categoryRef = useRef<HTMLInputElement>(null);
+    const [markdown, setMarkdown] = useState<string | undefined>(editPostData.markdown);
+    const [editPost, { data }] = useMutation<MutationResult>(`/api/blogs/post/edit?id=${editPostData.id}`);
+    const { data: session } = useSession();
+
+
+
+    const splitTags = (): string[] | void => {
+        let { value } = tagsRef?.current!;
+
+        if (value === "") return;
+        const splitArr = value.split(", ");
+        const set = splitArr.filter((el, index) => {
+            return splitArr.indexOf(el) === index;
+        });
+        return set;
+    };
+
+    const handleSubmit = async (e: any) => {
+
+        e.preventDefault()
+
+        if (session?.user?.email !== process.env.MY_EMAIL) {
+            if (process.env.NODE_ENV === "production") {
+                return alert("email 확인해주세요");
+            }
+        }
+
+        const postJson: PostPostJson = {
+            title: titleRef.current?.value!,
+            markdown,
+            description: descriptionRef.current?.value!,
+            tags: splitTags(),
+            category: categoryRef.current?.value!,
+        };
+
+        await editPost(postJson);
+
+        if (data?.ok === false) {
+            alert("인터넷 오류");
+        } else {
+            router.replace("/");
+        }
+    };
+
+
+
+    return (
+        <>
+            <form className="items-center justify-center flex flex-col ">
+                <div className="flex mt-5 gap-10 mb-10">
+                    <div>
+                        <span>Title - </span>
+                        <input
+                            className="outline-none border-2 border-solid border-black focus:border-gray-300 p-1"
+                            type="text"
+                            ref={titleRef}
+                            required
+                            defaultValue={editPostData.title}
+                        />
+                    </div>
+                    <div>
+                        <span>Tags - </span>
+                        <input
+                            className="outline-none border-2 border-solid border-black focus:border-gray-300 p-1"
+                            type="text"
+                            ref={tagsRef}
+                            placeholder="tag들은 , 로 분리함"
+                            required
+                            defaultValue={editPostDataTags}
+                        />
+                    </div>
+                    <div>
+                        <span>Description - </span>
+                        <input
+                            className="outline-none border-2 border-solid border-black focus:border-gray-300 p-1"
+                            type="text"
+                            ref={descriptionRef}
+                            placeholder="줄거리 입력"
+                            required
+                            defaultValue={editPostData.description}
+                        />
+                    </div>
+
+                    <div>
+                        <span>Category - </span>
+                        <input
+                            className="outline-none border-2 border-solid border-black focus:border-gray-300 p-1"
+                            type="text"
+                            ref={categoryRef}
+                            placeholder="카테고리 입력"
+                            defaultValue={editPostData.category?.category}
+                        />
+                    </div>
+                </div>
+                <MDEditor
+                    className="w-4/5 prose"
+                    defaultValue={editPostData.markdown}
+                    value={markdown}
+                    onChange={(value) => setMarkdown(value)}
+                />
+
+                <button
+                    onClick={handleSubmit}
+                    className="text-center w-1/3 my-10 ring-2 ring-offset-2 ring-gray-400 py-2 block hover:bg-gray-400 hover:text-green-50"
+                >
+                    Submit
+                </button>
+            </form>
+
+        </>
+    );
+}

--- a/app/blogs/post/edit/page.tsx
+++ b/app/blogs/post/edit/page.tsx
@@ -31,15 +31,14 @@ export default function Page() {
 
 
 
-    const splitTags = (): string[] | void => {
-        let { value } = tagsRef?.current!;
+    const splitTags = (): string[] => {
+        const { value } = tagsRef?.current!;
 
-        if (value === "") return;
+        if (value === "") return [""]
         const splitArr = value.split(", ");
-        const set = splitArr.filter((el, index) => {
+        return splitArr.filter((el, index) => {
             return splitArr.indexOf(el) === index;
         });
-        return set;
     };
 
     const handleSubmit = async (e: any) => {

--- a/app/blogs/post/page.tsx
+++ b/app/blogs/post/page.tsx
@@ -9,16 +9,11 @@ import "@uiw/react-markdown-preview/markdown.css";
 import { useMutation } from "@libs/client/useMutation";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
+import {MutationResult, PostPostJson} from '@types'
 
-export interface IPostJson {
-    title: string;
-    markdown: string | undefined;
-    tags?: string[] | void;
-    description: string;
-    category?: string;
-}
 
-type MutationResult = { ok: boolean };
+
+
 
 const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
 
@@ -53,7 +48,7 @@ export default function Page() {
             }
         }
 
-        const postJson: IPostJson = {
+        const postJson: PostPostJson = {
             title: titleRef.current?.value!,
             markdown,
             description: descriptionRef.current?.value!,

--- a/app/blogs/post/page.tsx
+++ b/app/blogs/post/page.tsx
@@ -1,18 +1,14 @@
 "use client"
 
-import React, { useState } from "react";
+import React, {useRef, useState} from "react";
 import ImageForm from "@components/Post/ImageForm";
 import dynamic from "next/dynamic";
-import { useRef } from "react";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
-import { useMutation } from "@libs/client/useMutation";
-import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
+import {useMutation} from "@libs/client/useMutation";
+import {useRouter} from "next/navigation";
+import {useSession} from "next-auth/react";
 import {MutationResult, PostPostJson} from '@types'
-
-
-
 
 
 const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
@@ -27,15 +23,14 @@ export default function Page() {
     const [postBlog, { data }] = useMutation<MutationResult>("/api/blogs/post");
     const { data: session } = useSession();
 
-    const splitTags = (): string[] | void => {
-        let { value } = tagsRef?.current!;
+    const splitTags = (): string[] => {
+        const { value } = tagsRef?.current!;
 
-        if (value === "") return;
+        if (value === "") return [""]
         const splitArr = value.split(", ");
-        const set = splitArr.filter((el, index) => {
+        return splitArr.filter((el, index) => {
             return splitArr.indexOf(el) === index;
         });
-        return set;
     };
 
     const handleSubmit = async (e: any) => {

--- a/components/Post/PostEditDeleteBox.tsx
+++ b/components/Post/PostEditDeleteBox.tsx
@@ -24,8 +24,7 @@ export default function PostEditDeleteBox({postData}:{postData:Post}) {
     })
 
     const dispatch = useDispatch();
-    const editPost = useCallback(() => {
-
+    const editPost = () => {
         dispatch(
             setPostJson({
                 id: +id,
@@ -34,22 +33,21 @@ export default function PostEditDeleteBox({postData}:{postData:Post}) {
                 description: postData.description,
                 markdown: postData.content,
                 // @ts-ignore
-                tags: postData.tags,
+                tags: postData.tags.map(item=>item.tag),
             })
-        );
-        return router.push("/blogs/post/route");
-    }, [
-  dispatch
-    ]);
+        )
+        return router.push("/blogs/post/edit");
+    }
+
 
     return (<div
-        className={cls(
-            session?.user?.email === process.env.MY_EMAIL
-                ? "visible"
-                : "invisible"
-        )}
+        // className={cls(
+        //     session?.user?.email === process.env.MY_EMAIL
+        //         ? "visible"
+        //         : "invisible"
+        // )}
     >
-        <div className="flex w-full justify-center mt-10 gap-10">
+        <div className="flex w-full justify-center mt-10 gap-10 cursor-pointer">
                   <span className="border-black border-2 rounded-xl p-2" onClick={editPost}>
                     수정
                   </span>

--- a/components/Post/PostEditDeleteBox.tsx
+++ b/components/Post/PostEditDeleteBox.tsx
@@ -41,11 +41,11 @@ export default function PostEditDeleteBox({postData}:{postData:Post}) {
 
 
     return (<div
-        // className={cls(
-        //     session?.user?.email === process.env.MY_EMAIL
-        //         ? "visible"
-        //         : "invisible"
-        // )}
+        className={cls(
+            session?.user?.email === process.env.MY_EMAIL
+                ? "visible"
+                : "invisible"
+        )}
     >
         <div className="flex w-full justify-center mt-10 gap-10 cursor-pointer">
                   <span className="border-black border-2 rounded-xl p-2" onClick={editPost}>

--- a/libs/server/findCategoryId.ts
+++ b/libs/server/findCategoryId.ts
@@ -14,7 +14,24 @@ export const findCategory = async (
       },
     });
 
-    return CategoryId === null ? null : CategoryId;
+
+      const confirmCategoryId= async () => {
+          if (CategoryId === null && category !== "") {
+              const newCategory = await prismaclient.category.create({
+                  data: {
+                      category: category!,
+                  },
+                  select: {
+                      id: true,
+                  },
+              })
+              return newCategory
+          }
+
+        return CategoryId
+      }
+
+      return confirmCategoryId()
   } catch (err) {
     console.log(err);
   }

--- a/store/modules/editPost.ts
+++ b/store/modules/editPost.ts
@@ -7,10 +7,9 @@ const initialState: EditPost = {
   id: 1,
   title: "",
   markdown: "",
-  tags: [""],
+  tags: [],
   description: "",
   category: {category: ''},
-
 };
 
 const editPostSlice = createSlice({
@@ -18,12 +17,13 @@ const editPostSlice = createSlice({
   initialState,
   reducers: {
     setPostJson: (state, action: PayloadAction<EditPost>) => {
-      const { id, markdown, tags, title, description } = action.payload;
+      const { id, markdown, tags, title, description,category } = action.payload;
       state.id = id;
       state.markdown = markdown;
       state.tags = tags;
       state.title = title;
       state.description = description;
+      state.category = category;
     },
   },
 });

--- a/type.d.ts
+++ b/type.d.ts
@@ -82,7 +82,7 @@ export interface EditPost extends Omit<Post, "tags" | "comments" | "createdAt" |
 export interface PostPostJson {
     title: string;
     markdown: string | undefined;
-    tags?: string[] | void;
+    tags?: string[];
     description: string;
     category?: string;
 }

--- a/type.d.ts
+++ b/type.d.ts
@@ -2,6 +2,7 @@ import { Tag} from '@prisma/client'
 
 export type PostStatus = "popular" | "recent";
 
+type MutationResult = { ok: boolean };
 
 export interface ThumbnailPostData {
     id:number
@@ -75,4 +76,13 @@ export interface EditPost extends Omit<Post, "tags" | "comments" | "createdAt" |
     id: number;
     markdown: string;
     tags: string[];
+    category?: {category:string},
+}
+
+export interface PostPostJson {
+    title: string;
+    markdown: string | undefined;
+    tags?: string[] | void;
+    description: string;
+    category?: string;
 }


### PR DESCRIPTION
# 블로그 post 수정

## api 

- edit route 생성 
- id query 사용
- post와 유사한 로직으로 구현

## page

- post 하는 페이지와 똑같은 UI로 구성

## function

####  findCategory

- 함수에게 역할을 더 주고 api/post와 함께 사용하는 중복 코드 제거 

#### findTags

- post/edit 에서 tag와 관련된 로직 수정



## type

type 정리하고 global 하게 사용 가능