### PR TITLE
Hotfix/edit

### DIFF
--- a/app/blogs/post/edit/page.tsx
+++ b/app/blogs/post/edit/page.tsx
@@ -19,6 +19,7 @@ export default function Page() {
 
     const editPostData = useSelector( (state:ReduxSliceState) => state.editPostReducer);
 
+
     const editPostDataTags = editPostData.tags.join("")
 
     const tagsRef = useRef<HTMLInputElement>(null);

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+import Lottie from 'lottie-react'
+import LoadingJson from "../public/lottie.json"
+
+export default function Loading(){
+    return <div>
+<Lottie animationData={LoadingJson} loop={true}/>
+    </div>
+}

--- a/components/Post/PostEditDeleteBox.tsx
+++ b/components/Post/PostEditDeleteBox.tsx
@@ -2,7 +2,6 @@
 
 import {cls} from '@libs/client/utils'
 import process from 'process'
-import React, {useCallback} from 'react'
 import {useSession} from 'next-auth/react'
 import {useMutation} from '@tanstack/react-query'
 import {deletePost} from '@libs/client/postFn'

--- a/components/Post/PostEditDeleteBox.tsx
+++ b/components/Post/PostEditDeleteBox.tsx
@@ -48,7 +48,7 @@ export default function PostEditDeleteBox({postData}:{postData:Post}) {
         )}
     >
         <div className="flex w-full justify-center mt-10 gap-10 cursor-pointer">
-                  <span className="border-black border-2 rounded-xl p-2" onClick={editPost}>
+                  <span className="border-black border-2 rounded-xl p-2" onClick={()=>editPost()}>
                     수정
                   </span>
             <span className="border-black border-2 rounded-xl p-2" onClick={() => deletePostMutation.mutate()}>


### PR DESCRIPTION
# Edit page에서 input에 데이터 없는 버그 발생

#### selector

- 문제 :  개발 환경에서는 적용이 잘 되었지만 상용에서 문제  useSelector에서 값을 받아와도 비어있는 값이 들어오고 한 번 더 눌러서 dispatch하며 이동하면 값이 채워저 있음 => edit page로 두번 이동해야함

click 이벤트에 dispatch와 route 이동 로직이 들어있는 함수를 객체로서 전달했음
바꾸거나 바꾸지 않거나 똑같은 일을 하는 코드지만 컨벤션을 맞췄고 작성해서 해결함 


# Page

전역에서 사용하는 loading page 추가