### PR TITLE
Configure LDJSON schema for SEO optimization

### DIFF
--- a/app/about-me/layout.tsx
+++ b/app/about-me/layout.tsx
@@ -1,0 +1,28 @@
+import JsonLd, { getBreadcrumbSchema, getProfilePageSchema, SITE_CONFIG } from "@shared/components/JsonLd";
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "About Me - 최정환 | Web Developer",
+  description: "새로운 도전과 내실 다지기를 즐기는 웹 개발자 최정환입니다. Next.js, React Native, Spring Boot 등을 활용한 풀스택 개발 경험을 보유하고 있습니다.",
+  openGraph: {
+    title: "About Me - 최정환",
+    description: "새로운 도전과 내실 다지기를 즐기는 웹 개발자 최정환입니다.",
+    url: `${SITE_CONFIG.url}/about-me`,
+  },
+};
+
+export default function AboutMeLayout({ children }: { children: React.ReactNode }) {
+  const breadcrumbSchema = getBreadcrumbSchema([
+    { name: "홈", url: SITE_CONFIG.url },
+    { name: "About Me", url: `${SITE_CONFIG.url}/about-me` },
+  ]);
+
+  return (
+    <>
+      <JsonLd data={getProfilePageSchema()} />
+      <JsonLd data={breadcrumbSchema} />
+      {children}
+    </>
+  );
+}

--- a/app/blogs/post/[id]/page.tsx
+++ b/app/blogs/post/[id]/page.tsx
@@ -1,5 +1,6 @@
 import PostDetailPage from "@domains/post/pages/post-detail.page";
 import { IPost } from "@domains/post/types";
+import JsonLd, { getBlogPostingSchema, getBreadcrumbSchema, SITE_CONFIG } from "@shared/components/JsonLd";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import process from "process";
@@ -84,5 +85,37 @@ export default async function Page(props: Props) {
     notFound();
   }
 
-  return <PostDetailPage postData={postData} />;
+  const postUrl = `${SITE_CONFIG.url}/blogs/post/${id}`;
+  const imageSrc = RegImageSrc(postData.content);
+  const ogImageUrl = imageSrc
+    ? imageSrc.startsWith("http")
+      ? imageSrc
+      : `${process.env.NEXT_PUBLIC_APIDOMAIN}${imageSrc}`
+    : undefined;
+
+  const blogPostingSchema = getBlogPostingSchema({
+    title: postData.title,
+    description: postData.description,
+    content: postData.content,
+    datePublished: postData.createdAt,
+    dateModified: postData.updatedAt,
+    url: postUrl,
+    image: ogImageUrl,
+    category: postData.category?.name,
+    tags: postData.tags?.map((tag) => tag.tag.name),
+  });
+
+  const breadcrumbSchema = getBreadcrumbSchema([
+    { name: "홈", url: SITE_CONFIG.url },
+    { name: "블로그", url: `${SITE_CONFIG.url}/blogs` },
+    { name: postData.title, url: postUrl },
+  ]);
+
+  return (
+    <>
+      <JsonLd data={blogPostingSchema} />
+      <JsonLd data={breadcrumbSchema} />
+      <PostDetailPage postData={postData} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import SlideHeaderNavBar from "@shared/components/NavBar/SlideHeaderNavBar";
 import Provider from "@shared/components/Provider";
+import JsonLd, { getOrganizationSchema, getWebSiteSchema } from "@shared/components/JsonLd";
 import { Metadata } from "next";
 import React from "react";
 
@@ -22,6 +23,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       lang="ko"
       suppressHydrationWarning
     >
+      <head>
+        <JsonLd data={getWebSiteSchema()} />
+        <JsonLd data={getOrganizationSchema()} />
+      </head>
       <body>
         <Provider>
           <SlideHeaderNavBar />

--- a/src/shared/components/JsonLd.tsx
+++ b/src/shared/components/JsonLd.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+
+type JsonLdProps = {
+  data: Record<string, unknown>;
+};
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+// 사이트 전체 정보
+export const SITE_CONFIG = {
+  name: "Jung's Tech Blog",
+  url: "https://www.junglog.xyz",
+  description:
+    "프론트엔드 개발을 중심으로, 서버 인프라까지 다양한 기술 분야를 학습하고 다루는 최정환의 기술 블로그입니다.",
+  author: {
+    name: "최정환",
+    url: "https://www.junglog.xyz/about-me",
+    github: "https://github.com/wjdghks963",
+    linkedin: "https://www.linkedin.com/in/junghwan-choi-a238b1228",
+  },
+  language: "ko-KR",
+};
+
+// WebSite 스키마 (홈페이지용)
+export function getWebSiteSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_CONFIG.name,
+    url: SITE_CONFIG.url,
+    description: SITE_CONFIG.description,
+    inLanguage: SITE_CONFIG.language,
+    author: {
+      "@type": "Person",
+      name: SITE_CONFIG.author.name,
+      url: SITE_CONFIG.author.url,
+    },
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${SITE_CONFIG.url}/blogs?search={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+}
+
+// Organization 스키마
+export function getOrganizationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: SITE_CONFIG.author.name,
+    url: SITE_CONFIG.author.url,
+    sameAs: [SITE_CONFIG.author.github, SITE_CONFIG.author.linkedin],
+  };
+}
+
+// BlogPosting 스키마 (블로그 포스트용)
+type BlogPostSchemaProps = {
+  title: string;
+  description: string;
+  content: string;
+  datePublished: string;
+  dateModified: string;
+  url: string;
+  image?: string;
+  category?: string;
+  tags?: string[];
+};
+
+export function getBlogPostingSchema({
+  title,
+  description,
+  content,
+  datePublished,
+  dateModified,
+  url,
+  image,
+  category,
+  tags,
+}: BlogPostSchemaProps) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description: description,
+    articleBody: content.substring(0, 5000), // 본문 일부만 포함
+    datePublished: datePublished,
+    dateModified: dateModified,
+    url: url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    author: {
+      "@type": "Person",
+      name: SITE_CONFIG.author.name,
+      url: SITE_CONFIG.author.url,
+    },
+    publisher: {
+      "@type": "Person",
+      name: SITE_CONFIG.author.name,
+      url: SITE_CONFIG.url,
+    },
+    ...(image && {
+      image: {
+        "@type": "ImageObject",
+        url: image,
+      },
+    }),
+    ...(category && { articleSection: category }),
+    ...(tags && tags.length > 0 && { keywords: tags.join(", ") }),
+    inLanguage: SITE_CONFIG.language,
+  };
+}
+
+// BreadcrumbList 스키마 (네비게이션용)
+type BreadcrumbItem = {
+  name: string;
+  url: string;
+};
+
+export function getBreadcrumbSchema(items: BreadcrumbItem[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+// Person 스키마 (About Me 페이지용)
+export function getPersonSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: SITE_CONFIG.author.name,
+    url: SITE_CONFIG.author.url,
+    jobTitle: "Web Developer",
+    worksFor: {
+      "@type": "Organization",
+      name: "프리텔레콤",
+    },
+    knowsAbout: [
+      "Next.js",
+      "React",
+      "React Native",
+      "TailwindCSS",
+      "Redux Toolkit",
+      "React Query",
+      "Spring Boot",
+      "Docker",
+      "AWS",
+    ],
+    sameAs: [SITE_CONFIG.author.github, SITE_CONFIG.author.linkedin],
+    alumniOf: {
+      "@type": "EducationalOrganization",
+      name: "정보처리기사",
+    },
+  };
+}
+
+// ProfilePage 스키마 (About Me 페이지용)
+export function getProfilePageSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    mainEntity: getPersonSchema(),
+    dateCreated: "2022-01-01",
+    dateModified: new Date().toISOString().split("T")[0],
+  };
+}


### PR DESCRIPTION
- JsonLd 재사용 컴포넌트 생성 (src/shared/components/JsonLd.tsx)
- 루트 레이아웃에 WebSite, Organization 스키마 추가
- 블로그 포스트 페이지에 BlogPosting, BreadcrumbList 스키마 추가
- About Me 페이지에 ProfilePage, Person, BreadcrumbList 스키마 추가

검색 엔진 최적화를 위한 구조화 데이터로 리치 스니펫 지원