### PR TITLE
fix(blogs): 검색 동작 수정 및 검색/로딩 UI 개선

### DIFF
--- a/app/api/blogs/route.ts
+++ b/app/api/blogs/route.ts
@@ -1,4 +1,5 @@
 import { PostWithId } from "@types";
+import { Prisma } from "@prisma/client";
 import { NextResponse } from "next/server";
 
 import prismaclient from "@libs/server/prismaClient";
@@ -6,67 +7,59 @@ import prismaclient from "@libs/server/prismaClient";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
-  const tag = searchParams.get("tag") !== "undefined" ? searchParams.get("tag")! + "" : "all";
-  const query = searchParams.get("query") !== "undefined" ? searchParams.get("query")! + "" : "";
-  const page = searchParams.get("page") !== "undefined" ? +searchParams.get("page")! : 1;
-  const limit = searchParams.get("limit") !== "undefined" ? +searchParams.get("limit")! : 5;
+  const rawTag = searchParams.get("tag");
+  const rawQuery = searchParams.get("query");
+  const rawPage = searchParams.get("page");
+  const rawLimit = searchParams.get("limit");
 
-  if (tag !== "all" && query === "") {
-    const posts: PostWithId[] = await prismaclient.$queryRaw<PostWithId[]>`
-      SELECT 
-            p.*, 
+  const tag = rawTag && rawTag !== "undefined" ? rawTag : "all";
+  const query = rawQuery && rawQuery !== "undefined" ? rawQuery.trim() : "";
+  const page = rawPage && rawPage !== "undefined" ? +rawPage : 1;
+  const limit = rawLimit && rawLimit !== "undefined" ? +rawLimit : 5;
+
+  const offset = (page - 1) * limit;
+  const hasTag = tag !== "all" && tag !== "";
+  const hasQuery = query !== "";
+
+  // 검색어와 태그 조건을 조합해 동적으로 WHERE 절을 구성한다.
+  const conditions: Prisma.Sql[] = [];
+
+  if (hasQuery) {
+    conditions.push(
+      Prisma.sql`(p.title ILIKE ${`%${query}%`} OR p.content ILIKE ${`%${query}%`})`
+    );
+  }
+
+  if (hasTag) {
+    // 태그로 필터링하되 json_agg 결과에는 모든 태그가 그대로 노출되도록 EXISTS 사용.
+    conditions.push(
+      Prisma.sql`EXISTS (
+        SELECT 1
+        FROM "PostTag" pt2
+        JOIN "Tag" t2 ON t2.id = pt2."tagId"
+        WHERE pt2."postId" = p.id AND t2.tag = ${tag}
+      )`
+    );
+  }
+
+  const whereClause = conditions.length
+    ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`
+    : Prisma.empty;
+
+  const posts: PostWithId[] = await prismaclient.$queryRaw<PostWithId[]>`
+      SELECT
+            p.*,
             COALESCE(json_agg(json_build_object('tag', t.tag)) FILTER (WHERE t.tag IS NOT NULL), '[]'::json) AS tags
-      FROM 
-            "Post"  p
-      LEFT JOIN 
-            "PostTag" pt ON p.id = pt."postId"
-      LEFT JOIN 
-            "Tag" t ON t.id = pt."tagId"
-      WHERE 
-            t.tag = ${tag}
-      GROUP BY p.id
-      ORDER BY p."createdAt" DESC
-      LIMIT ${limit} OFFSET ${(page - 1) * limit};
-`;
-
-    const hasNextPage = posts.length === limit;
-    return NextResponse.json({ data: posts, hasNextPage });
-  }
-
-  // 제목과 내용 중에 맞는 것이 있다면 전부 나오게 함
-  if (query !== "all" && tag === "") {
-    const posts: PostWithId[] = await prismaclient.$queryRaw<PostWithId[]>`
-    SELECT 
-        p.*, 
-        COALESCE(json_agg(json_build_object('tag', t.tag)) FILTER (WHERE t.tag IS NOT NULL), '[]'::json) AS tags
-    FROM 
-        "Post" p
-    LEFT JOIN 
-        "PostTag" AS pt ON p.id = pt."postId"
-    LEFT JOIN 
-        "Tag" AS t ON t.id = pt."tagId"
-    WHERE 
-        p.title LIKE ${`%${query}%`} OR p.content LIKE ${`%${query}%`}
-    GROUP BY p.id
-    ORDER BY p."createdAt" DESC
-    LIMIT ${limit} OFFSET ${(page - 1) * limit};
-    `;
-
-    const hasNextPage = posts.length === limit;
-    return NextResponse.json({ data: posts, hasNextPage });
-  }
-
-  const allPosts: PostWithId[] = await prismaclient.$queryRaw<PostWithId[]>`
-      SELECT p.*, COALESCE(json_agg(json_build_object('tag', t.tag)) FILTER (WHERE t.tag IS NOT NULL), '[]'::json) AS tags
       FROM "Post" p
       LEFT JOIN "PostTag" pt ON p.id = pt."postId"
       LEFT JOIN "Tag" t ON t.id = pt."tagId"
+      ${whereClause}
       GROUP BY p.id
       ORDER BY p."createdAt" DESC
-      LIMIT ${limit} OFFSET ${(page - 1) * limit};
-`;
+      LIMIT ${limit} OFFSET ${offset};
+  `;
 
-  const hasNextPage = allPosts.length === limit;
+  const hasNextPage = posts.length === limit;
 
-  return NextResponse.json({ data: allPosts, hasNextPage });
+  return NextResponse.json({ data: posts, hasNextPage });
 }

--- a/src/domains/post/components/InfiniteBlogs.tsx
+++ b/src/domains/post/components/InfiniteBlogs.tsx
@@ -72,9 +72,7 @@ export default function InfiniteBlogs() {
         aria-live="polite"
       >
         <span>
-          {isFilterLoading ? (
-            "불러오는 중…"
-          ) : allData.length > 0 ? (
+          {!isFilterLoading && allData.length > 0 ? (
             <>
               총 <span className="font-semibold text-[var(--text-primary)]">{allData.length}</span>개 포스트
               {hasNextPage ? " 표시 중" : ""}

--- a/src/domains/post/components/InfiniteBlogs.tsx
+++ b/src/domains/post/components/InfiniteBlogs.tsx
@@ -6,7 +6,7 @@ import { PostWithId } from "@domains/post/types";
 import useQuerySelector from "@shared/hooks/useQuerySelector";
 import useTagSelector from "@shared/hooks/useTagSelector";
 import { httpService } from "@shared/services/http.service";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import React, { useCallback, useEffect, useRef } from "react";
 
@@ -30,9 +30,14 @@ export default function InfiniteBlogs() {
     ): number | undefined {
       return lastPage.hasNextPage ? allPages.length + 1 : undefined;
     },
+    // 검색어·태그를 바꾸는 동안 이전 결과를 유지해 스켈레톤 깜빡임을 막는다.
+    placeholderData: keepPreviousData,
   });
 
-  const isFilterLoading = isFetching && !isFetchingNextPage;
+  // 최초 로딩(보여줄 데이터가 전혀 없을 때)에만 스켈레톤을 노출한다.
+  const showSkeleton = isLoading;
+  // 필터를 바꾸는 동안에는 기존 목록을 살짝 흐리게 처리한다.
+  const isRefreshing = isFetching && !isFetchingNextPage && !isLoading;
 
   const allData: PostWithId[] = data
     ? data.pages.reduce((prev, curr) => prev.concat(curr.data as PostWithId[]), [] as PostWithId[])
@@ -72,7 +77,7 @@ export default function InfiniteBlogs() {
         aria-live="polite"
       >
         <span>
-          {!isFilterLoading && allData.length > 0 ? (
+          {!showSkeleton && allData.length > 0 ? (
             <>
               총 <span className="font-semibold text-[var(--text-primary)]">{allData.length}</span>개 포스트
               {hasNextPage ? " 표시 중" : ""}
@@ -82,7 +87,7 @@ export default function InfiniteBlogs() {
       </div>
 
       <div className="min-h-[400px]">
-        {isFilterLoading ? (
+        {showSkeleton ? (
           <div className="grid grid-cols-1 gap-x-12 lg:grid-cols-2">
             {Array.from({ length: 4 }).map((_, idx) => (
               <div
@@ -126,7 +131,13 @@ export default function InfiniteBlogs() {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-x-12 lg:grid-cols-2">
+          <div
+            className="grid grid-cols-1 gap-x-12 lg:grid-cols-2"
+            style={{
+              opacity: isRefreshing ? 0.5 : 1,
+              transition: "opacity 150ms ease",
+            }}
+          >
             {allData?.map((data: PostWithId) => (
               <MiniPost key={data.id} data={data} />
             ))}
@@ -134,7 +145,7 @@ export default function InfiniteBlogs() {
         )}
       </div>
 
-      {(hasNextPage || isLoading) && !isFilterLoading && (
+      {(hasNextPage || isLoading) && !isRefreshing && (
         <div
           ref={loadingRef}
           className="flex justify-center py-10"

--- a/src/domains/post/components/SearchBar.tsx
+++ b/src/domains/post/components/SearchBar.tsx
@@ -22,10 +22,18 @@ export function SearchBar() {
     [dispatch]
   );
 
+  // 외부(예: 태그 선택)에서 검색어가 바뀌거나 초기화되면 입력창도 동기화한다.
   useEffect(() => {
+    setText(query ?? "");
+  }, [query]);
+
+  // 입력값을 디바운스해 검색 쿼리에 반영한다.
+  useEffect(() => {
+    if (text === query) return;
+
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
-      if (text !== query) dispatchQuery(text);
+      dispatchQuery(text);
     }, DEBOUNCE_MS);
 
     return () => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -275,3 +275,16 @@ h4 {
   background: transparent !important;
   color: #e2e8f0 !important;
 }
+
+/* 검색 인풋의 브라우저 기본 지우기(X) 버튼 숨기기 — 커스텀 "지우기" 버튼만 사용 */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[type="search"]::-ms-clear {
+  display: none;
+  width: 0;
+  height: 0;
+}


### PR DESCRIPTION
## 개요
`/blogs` 페이지의 검색 기능과 검색/로딩 UI 문제를 수정합니다.

## 문제 및 수정

### 1. 검색이 전혀 동작하지 않음 (핵심 버그) — `app/api/blogs/route.ts`
- **원인**: 검색어 조건이 `tag === ""`일 때만 동작했지만, 프론트엔드는 태그 기본값으로 항상 `"all"`을 전송합니다. 그 결과 검색어를 입력해도 어떤 분기에도 걸리지 않아 전체 글이 반환되며 검색이 무시되었습니다.
- **수정**: `query`·`tag` 조건을 `Prisma.sql`로 동적 조합(둘 다 / 하나만 / 없음 모두 정상 동작), 대소문자 무시를 위해 `ILIKE` 적용, 태그 필터는 `EXISTS`로 처리해 결과의 태그 목록은 그대로 노출.

### 2. 지우기 버튼이 2개 — `styles/globals.css`
- `type="search"` 인풋의 브라우저 기본 지우기(X) 버튼을 숨겨 커스텀 "지우기" 버튼만 남김.

### 3. 로딩 시 텍스트+스켈레톤 중복으로 미관상 별로 — `InfiniteBlogs.tsx`
- 스켈레톤과 함께 뜨던 "불러오는 중…" 텍스트 제거.

### 4. 태그를 선택해도 검색이 풀리지 않음 — `SearchBar.tsx`
- 태그 선택 시 redux 검색어는 초기화되지만 입력창 로컬 state가 남아, 디바운스 effect가 옛 검색어를 다시 dispatch하던 버그. 외부에서 검색어가 바뀌면 입력창을 동기화하도록 수정.

### 5. 키 입력마다 스켈레톤이 깜빡임 — `InfiniteBlogs.tsx`
- `keepPreviousData`를 적용해 검색 중에는 이전 목록을 유지하며 살짝 흐리게(opacity) 처리. 스켈레톤은 최초 진입 시에만 노출.

## 검증
- ✅ `tsc --noEmit` 타입체크 통과
- ⚠️ `next lint`는 무관한 파일에서도 동일하게 크래시하는 기존 ESLint 플러그인 버그로 실행 불가 (이번 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015k7KuF6MErHoXGhpaQeuKq)_