### PR TITLE
perf(blogs): 검색 요청 수 절감 (디바운스 500ms·최소 2자·캐시 강화)

### DIFF
--- a/src/domains/post/components/InfiniteBlogs.tsx
+++ b/src/domains/post/components/InfiniteBlogs.tsx
@@ -32,6 +32,10 @@ export default function InfiniteBlogs() {
     },
     // 검색어·태그를 바꾸는 동안 이전 결과를 유지해 스켈레톤 깜빡임을 막는다.
     placeholderData: keepPreviousData,
+    // 글 목록은 자주 바뀌지 않으므로 캐시를 길게 잡아, 같은 검색어·태그 재요청 시
+    // 네트워크 호출(=Vercel 함수 실행) 없이 캐시에서 즉시 응답한다.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 
   // 최초 로딩(보여줄 데이터가 전혀 없을 때)에만 스켈레톤을 노출한다.

--- a/src/domains/post/components/SearchBar.tsx
+++ b/src/domains/post/components/SearchBar.tsx
@@ -6,7 +6,9 @@ import { useDispatch } from "react-redux";
 
 import { setSearchQuery } from "@store/modules/searchQuery";
 
-const DEBOUNCE_MS = 300;
+const DEBOUNCE_MS = 400;
+// 1글자 검색은 매칭 범위가 지나치게 넓고 호출만 낭비하므로 최소 길이를 둔다.
+const MIN_QUERY_LENGTH = 2;
 
 export function SearchBar() {
   const dispatch = useDispatch();
@@ -30,6 +32,8 @@ export function SearchBar() {
   // 입력값을 디바운스해 검색 쿼리에 반영한다.
   useEffect(() => {
     if (text === query) return;
+    // 빈 문자열(전체 보기)은 허용하고, 1글자처럼 너무 짧은 검색어는 요청을 보내지 않는다.
+    if (text.length > 0 && text.length < MIN_QUERY_LENGTH) return;
 
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {

--- a/src/domains/post/components/SearchBar.tsx
+++ b/src/domains/post/components/SearchBar.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from "react-redux";
 
 import { setSearchQuery } from "@store/modules/searchQuery";
 
-const DEBOUNCE_MS = 400;
+const DEBOUNCE_MS = 500;
 // 1글자 검색은 매칭 범위가 지나치게 넓고 호출만 낭비하므로 최소 길이를 둔다.
 const MIN_QUERY_LENGTH = 2;
 


### PR DESCRIPTION
## 개요
PR #40(검색 동작 수정·지우기 버튼·로딩 스켈레톤·태그 동기화)에 이어, **검색 API 요청 수를 줄여 무료 Vercel 환경에 맞게 경량화**합니다. 쿼리 로직은 그대로 두고 함수 호출(=Vercel 함수 실행) 횟수만 줄입니다.

## 변경 내용
- **최소 검색 길이 2자** (`SearchBar.tsx`): 1글자 검색은 매칭 범위가 지나치게 넓고 호출만 낭비하므로 요청을 보내지 않음. 빈 문자열(전체 보기)은 그대로 허용.
- **디바운스 300ms → 500ms** (`SearchBar.tsx`): 연속 입력 중 중간 API 호출을 더 줄임.
- **목록 쿼리 캐시 강화** (`InfiniteBlogs.tsx`): `staleTime` 5분 / `gcTime` 10분 적용 → 같은 검색어·태그 재요청 시 네트워크 호출 없이 캐시에서 응답.

## 참고
- 검색 쿼리(`title OR content ILIKE '%x%'`)는 의도적으로 그대로 둠. 현재 글 수 규모에선 풀스캔 비용이 미미하고, 무료 Vercel의 실제 병목은 함수 호출 횟수/실행시간이라 거기에 집중.
- 추후 글이 크게 늘어 검색이 느려지면 `pg_trgm` GIN 인덱스로 부분일치도 인덱스화 가능.

## 검증
- ✅ `tsc --noEmit` 타입체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015k7KuF6MErHoXGhpaQeuKq)_