### PR TITLE
feat: 블로그 상세 페이지에 같은 카테고리 이전/다음 글 네비게이션 추가

### DIFF
--- a/app/api/blogs/[id]/route.ts
+++ b/app/api/blogs/[id]/route.ts
@@ -52,7 +52,23 @@ export async function GET(request: Request) {
                     FROM "Tag" t
                     JOIN "PostTag" pt ON t.id = pt."tagId"
                     WHERE pt."postId" = "Post".id
-                  ) AS tags
+                  ) AS tags,
+                  (
+                    SELECT json_build_object('id', p.id, 'title', p.title, 'createdAt', p."createdAt")
+                    FROM "Post" p
+                    WHERE p."categoryId" = "Post"."categoryId"
+                      AND (p."createdAt", p.id) < ("Post"."createdAt", "Post".id)
+                    ORDER BY p."createdAt" DESC, p.id DESC
+                    LIMIT 1
+                  ) AS "prevPost",
+                  (
+                    SELECT json_build_object('id', p.id, 'title', p.title, 'createdAt', p."createdAt")
+                    FROM "Post" p
+                    WHERE p."categoryId" = "Post"."categoryId"
+                      AND (p."createdAt", p.id) > ("Post"."createdAt", "Post".id)
+                    ORDER BY p."createdAt" ASC, p.id ASC
+                    LIMIT 1
+                  ) AS "nextPost"
                 FROM "Post"
                 WHERE id = ${postId}
 `;
@@ -76,6 +92,8 @@ export async function GET(request: Request) {
       category: post?.category,
       createdAt: post?.createdAt,
       updatedAt: post?.updatedAt,
+      prevPost: post?.prevPost ?? null,
+      nextPost: post?.nextPost ?? null,
     });
   } catch (err) {
     console.error(err);

--- a/src/domains/post/components/PostNeighborNav.tsx
+++ b/src/domains/post/components/PostNeighborNav.tsx
@@ -1,0 +1,57 @@
+import { IAdjacentPost } from "@domains/post/types";
+import Link from "next/link";
+
+type Props = {
+  prevPost?: IAdjacentPost | null;
+  nextPost?: IAdjacentPost | null;
+};
+
+export default function PostNeighborNav({ prevPost, nextPost }: Props) {
+  if (!prevPost && !nextPost) return null;
+
+  return (
+    <nav
+      className="grid gap-6 sm:grid-cols-2"
+      style={{ marginTop: 48, paddingTop: 24, borderTop: "1px solid var(--rule)" }}
+    >
+      {prevPost ? <NeighborLink post={prevPost} label="← 이전 글" /> : <div />}
+      {nextPost && <NeighborLink post={nextPost} label="다음 글 →" align="right" />}
+    </nav>
+  );
+}
+
+function NeighborLink({
+  post,
+  label,
+  align = "left",
+}: {
+  post: IAdjacentPost;
+  label: string;
+  align?: "left" | "right";
+}) {
+  return (
+    <Link
+      href={`/blogs/post/${post.id}`}
+      prefetch={false}
+      className="group block"
+      style={{ textAlign: align }}
+    >
+      <div className="tiny-label" style={{ color: "var(--ink-3)", marginBottom: 8 }}>
+        {label}
+      </div>
+      <div
+        className="font-serif group-hover:underline"
+        style={{
+          fontSize: 18,
+          lineHeight: 1.25,
+          letterSpacing: "-0.01em",
+          fontWeight: 500,
+          color: "var(--ink)",
+          textDecorationThickness: 1,
+        }}
+      >
+        {post.title}
+      </div>
+    </Link>
+  );
+}

--- a/src/domains/post/pages/post-detail.page.tsx
+++ b/src/domains/post/pages/post-detail.page.tsx
@@ -1,6 +1,7 @@
 import EditorialToc from "@domains/post/components/EditorialToc";
 import MarkdownParser from "@domains/post/components/MarkdownParser";
 import PostEditDeleteBox from "@domains/post/components/PostEditDeleteBox";
+import PostNeighborNav from "@domains/post/components/PostNeighborNav";
 import ReadingProgressBar from "@domains/post/components/ReadingProgressBar";
 import { IPost } from "@domains/post/types";
 import { categoryColor } from "@domains/home/utils/categoryColor";
@@ -151,6 +152,8 @@ export default function PostDetailPage({ postData }: Props) {
           <div className="markdown-content editorial-body">
             <MarkdownParser markdown={postData.content} />
           </div>
+
+          <PostNeighborNav prevPost={postData.prevPost} nextPost={postData.nextPost} />
         </article>
 
         {/* Right TOC column */}

--- a/src/domains/post/types/post.types.ts
+++ b/src/domains/post/types/post.types.ts
@@ -29,6 +29,12 @@ export interface InfinitePostArr {
 
 export type PostsIds = [{ id: number }];
 
+export interface IAdjacentPost {
+  id: number;
+  title: string;
+  createdAt: string;
+}
+
 export interface IPost {
   title: string;
   content: string;
@@ -39,5 +45,7 @@ export interface IPost {
   createdAt: Date;
   updatedAt: Date;
   comments: (Comment | null)[];
+  prevPost?: IAdjacentPost | null;
+  nextPost?: IAdjacentPost | null;
 }
 

--- a/type.d.ts
+++ b/type.d.ts
@@ -54,6 +54,12 @@ export interface CommentEditJson {
   content: string;
 }
 
+export interface IAdjacentPost {
+  id: number;
+  title: string;
+  createdAt: string;
+}
+
 export interface IPost {
   title: string;
   content: string;
@@ -64,6 +70,8 @@ export interface IPost {
   createdAt: Date;
   updatedAt: Date;
   comments: (Comment | null)[];
+  prevPost?: IAdjacentPost | null;
+  nextPost?: IAdjacentPost | null;
 }
 
 export type CommentWithUser = { id: number; content: string; user: UserInfo };


### PR DESCRIPTION
- /api/blogs/[id] 응답에 같은 카테고리 내 prevPost/nextPost 추가
  (createdAt + id 타이브레이크로 정렬, 카테고리 없으면 null)
- PostNeighborNav 컴포넌트 신설 후 본문 하단에 렌더
- IPost 타입(post.types.ts, type.d.ts)에 prevPost/nextPost 필드 추가

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XedkqcZ4zL1GuwccHWUPh