### PR TITLE
feat: /blogs에 카테고리 필터링 추가

### DIFF
--- a/app/api/blogs/route.ts
+++ b/app/api/blogs/route.ts
@@ -8,17 +8,20 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
   const rawTag = searchParams.get("tag");
+  const rawCategory = searchParams.get("category");
   const rawQuery = searchParams.get("query");
   const rawPage = searchParams.get("page");
   const rawLimit = searchParams.get("limit");
 
   const tag = rawTag && rawTag !== "undefined" ? rawTag : "all";
+  const category = rawCategory && rawCategory !== "undefined" ? rawCategory : "all";
   const query = rawQuery && rawQuery !== "undefined" ? rawQuery.trim() : "";
   const page = rawPage && rawPage !== "undefined" ? +rawPage : 1;
   const limit = rawLimit && rawLimit !== "undefined" ? +rawLimit : 5;
 
   const offset = (page - 1) * limit;
   const hasTag = tag !== "all" && tag !== "";
+  const hasCategory = category !== "all" && category !== "";
   const hasQuery = query !== "";
 
   // 검색어와 태그 조건을 조합해 동적으로 WHERE 절을 구성한다.
@@ -42,6 +45,16 @@ export async function GET(request: Request) {
     );
   }
 
+  if (hasCategory) {
+    conditions.push(
+      Prisma.sql`EXISTS (
+        SELECT 1
+        FROM "Category" c2
+        WHERE c2.id = p."categoryId" AND c2.category = ${category}
+      )`
+    );
+  }
+
   const whereClause = conditions.length
     ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`
     : Prisma.empty;
@@ -49,6 +62,7 @@ export async function GET(request: Request) {
   const posts: PostWithId[] = await prismaclient.$queryRaw<PostWithId[]>`
       SELECT
             p.*,
+            (SELECT c.category FROM "Category" c WHERE c.id = p."categoryId") AS category,
             COALESCE(json_agg(json_build_object('tag', t.tag)) FILTER (WHERE t.tag IS NOT NULL), '[]'::json) AS tags
       FROM "Post" p
       LEFT JOIN "PostTag" pt ON p.id = pt."postId"

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -11,5 +11,14 @@ export default async function BlogsPage() {
     },
   });
 
-  return <PostListPage tags={tags} />;
+  const categories = await prismaclient.category.findMany({
+    select: {
+      category: true,
+    },
+    orderBy: {
+      category: "asc",
+    },
+  });
+
+  return <PostListPage tags={tags} categories={categories} />;
 }

--- a/src/domains/post/components/CategoryNavBar.tsx
+++ b/src/domains/post/components/CategoryNavBar.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { categoryColor } from "@domains/home/utils/categoryColor";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import React, { useCallback } from "react";
+
+interface CategoryNavBarProps {
+  categories: { category: string }[];
+}
+
+export default function CategoryNavBar({ categories }: CategoryNavBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const current = searchParams.get("category") ?? "all";
+
+  const selectCategory = useCallback(
+    (category: string) => {
+      // 카테고리를 바꿀 때는 검색어를 초기화하되, 태그 선택은 유지한다.
+      const params = new URLSearchParams();
+      const tag = searchParams.get("tag");
+      if (tag && tag !== "all") {
+        params.set("tag", tag);
+      }
+      if (category !== "all") {
+        params.set("category", category);
+      }
+      const queryString = params.toString();
+      router.push(queryString ? `${pathname}?${queryString}` : pathname);
+    },
+    [searchParams, router, pathname]
+  );
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <CategoryChip name="all" label="전체" active={current === "all"} onSelect={selectCategory} />
+      {categories.map((item) => (
+        <CategoryChip
+          key={item.category}
+          name={item.category}
+          label={item.category}
+          active={current === item.category}
+          onSelect={selectCategory}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CategoryChip({
+  name,
+  label,
+  active,
+  onSelect,
+}: {
+  name: string;
+  label: string;
+  active: boolean;
+  onSelect: (category: string) => void;
+}) {
+  const color = name === "all" ? "var(--ink)" : categoryColor(name);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(name)}
+      className="cursor-pointer rounded-full border px-2.5 py-1 font-mono text-[11px] transition-colors hover:bg-[var(--paper-2)]"
+      style={{
+        color: active ? color : "var(--ink-2)",
+        borderColor: active ? color : "var(--rule)",
+        fontWeight: active ? 600 : 400,
+        background: "transparent",
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/domains/post/components/InfiniteBlogs.tsx
+++ b/src/domains/post/components/InfiniteBlogs.tsx
@@ -13,14 +13,15 @@ export default function InfiniteBlogs() {
   const loadingRef = useRef<HTMLDivElement>(null);
   const searchParams = useSearchParams();
   const tag = searchParams.get("tag") ?? "all";
+  const category = searchParams.get("category") ?? "all";
   const query = searchParams.get("query") ?? "";
 
   const { data, fetchNextPage, hasNextPage, isLoading, isFetching, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: postQueryKeys.list({ tag, query }),
+    queryKey: postQueryKeys.list({ tag, query, category }),
     queryFn: async ({ pageParam }) => {
       const url = `/api/blogs?query=${encodeURIComponent(query)}&tag=${encodeURIComponent(
         tag
-      )}&page=${pageParam}&limit=5`;
+      )}&category=${encodeURIComponent(category)}&page=${pageParam}&limit=5`;
       return httpService.get<{ hasNextPage: boolean; data: PostWithId[] }>(url);
     },
     initialPageParam: 1,

--- a/src/domains/post/components/MiniPost.tsx
+++ b/src/domains/post/components/MiniPost.tsx
@@ -10,7 +10,7 @@ export default function MiniPost({ data }: { data: PostWithId }) {
   const date = compareLocaleDate(data.updatedAt, data.createdAt);
   const readingTime = getReadingTime(data.content);
   const href = `/blogs/post/${data.id}`;
-  const cat = (data as PostWithId & { category?: string | null }).category ?? null;
+  const cat = data.category ?? null;
   const color = categoryColor(cat);
 
   return (

--- a/src/domains/post/pages/post-detail.page.tsx
+++ b/src/domains/post/pages/post-detail.page.tsx
@@ -54,7 +54,13 @@ export default function PostDetailPage({ postData }: Props) {
               <MetaRow
                 k="카테고리"
                 v={
-                  <span style={{ color: catColor, fontWeight: 600 }}>{postData.category}</span>
+                  <Link
+                    href={`/blogs?category=${encodeURIComponent(postData.category)}`}
+                    className="hover:underline"
+                    style={{ color: catColor, fontWeight: 600 }}
+                  >
+                    {postData.category}
+                  </Link>
                 }
               />
             )}
@@ -93,11 +99,14 @@ export default function PostDetailPage({ postData }: Props) {
         {/* Article body */}
         <article style={{ minWidth: 0 }}>
           {postData.category && (
-            <div
-              className="tiny-label"
-              style={{ color: catColor, fontWeight: 600, marginBottom: 14 }}
-            >
-              {postData.category}
+            <div style={{ marginBottom: 14 }}>
+              <Link
+                href={`/blogs?category=${encodeURIComponent(postData.category)}`}
+                className="tiny-label hover:underline"
+                style={{ color: catColor, fontWeight: 600 }}
+              >
+                {postData.category}
+              </Link>
             </div>
           )}
           <h1

--- a/src/domains/post/pages/post-list.page.tsx
+++ b/src/domains/post/pages/post-list.page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import CategoryNavBar from "@domains/post/components/CategoryNavBar";
 import InfiniteBlogs from "@domains/post/components/InfiniteBlogs";
 import { SearchBar } from "@domains/post/components/SearchBar";
 import TagNavBar from "@domains/post/components/TagNavBar";
@@ -8,9 +9,10 @@ import React, { Suspense } from "react";
 
 interface PostListPageProps {
   tags: { tag: string }[];
+  categories: { category: string }[];
 }
 
-export default function PostListPage({ tags }: PostListPageProps) {
+export default function PostListPage({ tags, categories }: PostListPageProps) {
   return (
     <main
       className="min-h-screen"
@@ -50,9 +52,21 @@ export default function PostListPage({ tags }: PostListPageProps) {
             color: "var(--ink-2)",
           }}
         >
-          태그·키워드로 글을 좁혀 봅니다. 카테고리는 좌측 상단 네비게이션에서.
+          카테고리·태그·키워드로 글을 좁혀 봅니다.
         </p>
       </header>
+
+      <section
+        className="px-6 mobile:px-14"
+        style={{ paddingTop: 20, paddingBottom: 20, borderBottom: "1px solid var(--rule)" }}
+      >
+        <div className="tiny-label" style={{ color: "var(--ink-3)", marginBottom: 10 }}>
+          카테고리로 좁히기
+        </div>
+        <Suspense fallback={<div className="h-7" />}>
+          <CategoryNavBar categories={categories} />
+        </Suspense>
+      </section>
 
       <section
         className="px-6 mobile:px-14"

--- a/src/domains/post/services/post.service.ts
+++ b/src/domains/post/services/post.service.ts
@@ -53,7 +53,7 @@ export class PostService {
 
 export const postQueryKeys = {
   all: ["posts"] as const,
-  list: (filter: { tag: string; query: string }) => ["posts", filter] as const,
+  list: (filter: { tag: string; query: string; category: string }) => ["posts", filter] as const,
   detail: (id: number) => ["post", id] as const,
 };
 

--- a/src/domains/post/types/post.types.ts
+++ b/src/domains/post/types/post.types.ts
@@ -17,6 +17,7 @@ export type PostWithId = {
   content: string;
   views: number;
   description: string;
+  category?: string | null;
   createdAt: Date;
   updatedAt: Date;
   tags: Tag[];

--- a/src/shared/components/TagSpan.tsx
+++ b/src/shared/components/TagSpan.tsx
@@ -23,8 +23,15 @@ export default function TagSpan({ tag, tagName, className, clickOk, goBlog }: Ta
   const hiddenFlex = className ?? "";
 
   const buildTagParams = useCallback(() => {
-    // 태그를 바꿀 때는 검색어를 함께 초기화한다.
+    // 태그를 바꿀 때는 검색어를 초기화하되, 카테고리 선택은 유지한다.
     const params = new URLSearchParams();
+    const category =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("category")
+        : null;
+    if (category) {
+      params.set("category", category);
+    }
     if (tag && tag !== "all") {
       params.set("tag", tag);
     }

--- a/type.d.ts
+++ b/type.d.ts
@@ -25,6 +25,7 @@ export type PostWithId = {
   content: string;
   views: number;
   description: string;
+  category?: string | null;
   createdAt: Date;
   updatedAt: Date;
   tags: Tag[];


### PR DESCRIPTION
## 개요

`/blogs` 목록 페이지에서 태그·검색어에 더해 **카테고리로도 필터링**할 수 있습니다 (`/blogs?category=Dev`).

## 변경 내용

- **카테고리 칩 필터 UI** (`CategoryNavBar.tsx` 신규) — "태그로 좁히기" 위에 "카테고리로 좁히기" 섹션 추가. 선택된 칩은 카테고리 고유 색으로 하이라이트되고 "전체"로 해제합니다.
- **API** (`app/api/blogs/route.ts`) — `category` 쿼리 파라미터 추가(EXISTS 서브쿼리 필터), 응답 각 항목에 카테고리 이름 포함.
- **필터 조합** — 카테고리↔태그 선택이 서로 유지되어 함께 필터링됩니다. 검색어는 기존 정책대로 필터 변경 시 초기화.
- **상세 페이지 진입점** — 글 상세의 카테고리 라벨 2곳(왼쪽 메타, 제목 위)을 `/blogs?category=...` 링크로 변경.
- **잠복 버그 해결** — `MiniPost`가 카테고리 라벨을 표시하는 코드는 있었지만 목록 API가 이름을 내려주지 않아 항상 비어 있던 문제가 함께 해결되어, 목록 카드에도 카테고리가 표시됩니다.
- 타입: `PostWithId.category?: string | null` 추가(중복 정의된 두 곳 모두), `postQueryKeys.list` 필터에 `category` 포함.

## 검증

- `tsc --noEmit` 통과.
- 로컬 PostgreSQL + dev 서버에서 API 케이스 확인: 카테고리별 필터, 카테고리+태그 조합, 매치 없음(빈 배열), 미지정 시 전체.
- Playwright로 브라우저 확인: 칩 클릭 → URL/목록/하이라이트 갱신, 태그 클릭 시 카테고리 유지, "전체" 클릭 시 카테고리만 해제, 상세 페이지 카테고리 링크 동작.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XedkqcZ4zL1GuwccHWUPh)_